### PR TITLE
fix rgba colors

### DIFF
--- a/app/js/jail_iframe/classes/icon_buttons.coffee
+++ b/app/js/jail_iframe/classes/icon_buttons.coffee
@@ -64,7 +64,7 @@ class IconButton
     targetColor = style.color
 
     # See https://gamedev.stackexchange.com/questions/38536/given-a-rgb-color-x-how-to-find-the-most-contrasting-color-y/38561#38561
-    targetRGB = targetColor.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/)
+    targetRGB = targetColor.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(,\s*\d+(\.\d+)?)?\)$/)
     r = targetRGB[1]/255; g = targetRGB[2]/255; b = targetRGB[3]/255;
     targetBrightness = 0.2126*r*r + 0.7152*g*g + 0.0722*b*b
 


### PR DESCRIPTION
I had an issue with the script that crashed it on a site with a font color `rgba(0, 0, 0, 0.8)`. This fix should ensure graceful handling of both rgb and rgba definitions.

I was going to test and build it, but I use neither coffee, nor bundler, nor grunt… ;) So this is pretty much uncharted territory for me. After installing all the dependencies, building _without any changes_ produces different `.min` that is stored in the repo — I don’t understand why and I don’t want to break anything, but I hope this diff is enough for you to finish it and merge it in. 
